### PR TITLE
Drop `pip-compile` step from dev env setup

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,6 @@ deps =
     pre-commit
 commands =
     python -m pip install --upgrade pip
-    pip-compile pyproject.toml
     pip install -r requirements.txt
     pre-commit install
 


### PR DESCRIPTION
for better reproducability