### PR TITLE
Don't use (same) empty list as Field default, use default factory instead

### DIFF
--- a/src/migmose/mig/nestednachrichtenstruktur.py
+++ b/src/migmose/mig/nestednachrichtenstruktur.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, Tuple
 
 from loguru import logger
 from maus.edifact import EdifactFormat
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from migmose.mig.nachrichtenstrukturtabelle import NachrichtenstrukturTabelle
 from migmose.mig.nachrichtenstrukturzeile import NachrichtenstrukturZeile
@@ -66,8 +66,8 @@ class NestedNachrichtenstruktur(BaseModel):
     """
 
     header_linie: Optional[NachrichtenstrukturZeile] = None
-    segmente: list[Optional[NachrichtenstrukturZeile]] = []
-    segmentgruppen: list[Optional["NestedNachrichtenstruktur"]] = []
+    segmente: list[Optional[NachrichtenstrukturZeile]] = Field(default_factory=list)
+    segmentgruppen: list[Optional["NestedNachrichtenstruktur"]] = Field(default_factory=list)
 
     @classmethod
     def create_nested_nachrichtenstruktur(

--- a/src/migmose/mig/reducednestednachrichtenstruktur.py
+++ b/src/migmose/mig/reducednestednachrichtenstruktur.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, TypeAlias
 
 from loguru import logger
 from maus.edifact import EdifactFormat
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from migmose.mig.nachrichtenstrukturzeile import NachrichtenstrukturZeile
 from migmose.mig.nestednachrichtenstruktur import NestedNachrichtenstruktur
@@ -30,8 +30,8 @@ class ReducedNestedNachrichtenstruktur(BaseModel):
     """will contain the tree structure of nachrichtenstruktur tables"""
 
     header_linie: Optional[NachrichtenstrukturZeile] = None
-    segmente: list[Optional[NachrichtenstrukturZeile]] = []
-    segmentgruppen: list[Optional["ReducedNestedNachrichtenstruktur"]] = []
+    segmente: list[Optional[NachrichtenstrukturZeile]] = Field(default_factory=list)
+    segmentgruppen: list[Optional["ReducedNestedNachrichtenstruktur"]] = Field(default_factory=list)
 
     @classmethod
     def create_reduced_nested_nachrichtenstruktur(

--- a/unittests/test_nestednachrichtenstruktur.py
+++ b/unittests/test_nestednachrichtenstruktur.py
@@ -22,6 +22,7 @@ class TestNestedNachrichtenstruktur:
             nachrichtenstrukturtabelle
         )
         assert len(nested_nachrichtenstruktur.segmente) == 5
+        # pylint: disable=unsubscriptable-object
         assert len(nested_nachrichtenstruktur.segmentgruppen[3].segmentgruppen) == 1
 
     def test_to_json(self, tmp_path):


### PR DESCRIPTION
ich weiß nicht, ob es sich bei pydantic wie bei default default leeren listen als funktionsargumenten verhält...